### PR TITLE
Feature/limita nós

### DIFF
--- a/sinapse/start.py
+++ b/sinapse/start.py
@@ -266,7 +266,10 @@ def api_nextNodes():
         data=json.dumps(query),
         auth=_AUTH,
         headers=_HEADERS)
-    return respostajson(response)
+
+    numero_expansoes = conta_expansoes(node_id)
+
+    return respostajson(response, numero_de_expansoes=numero_expansoes)
 
 
 @app.route("/api/nodeProperties")

--- a/sinapse/start.py
+++ b/sinapse/start.py
@@ -101,6 +101,21 @@ def conta_nos(label, prop, val):
     return response.json()['results'][0]['data'][0]['row'][0]
 
 
+def conta_expansoes(n_id):
+    query = {"statements": [{
+        "statement": "MATCH r = (n)-[*..1]-(x) where id(n) = %s"
+        " return count(r), count(n), count(x)" % n_id,
+    }]}
+
+    response = requests.post(
+        _ENDERECO_NEO4J % '/db/data/transaction/commit',
+        data=json.dumps(query),
+        auth=_AUTH,
+        headers=_HEADERS)
+
+    return response.json()['results'][0]['data'][0]['row']
+
+
 def resposta_sensivel(resposta):
     def parser_dicionario(dicionario, chave):
         if isinstance(dicionario, dict):

--- a/sinapse/start.py
+++ b/sinapse/start.py
@@ -25,15 +25,18 @@ from sinapse.buildup import (
 )
 
 
-def respostajson(response):
+def respostajson(response, **kwargs):
     usuario = session.get('usuario', "dummy")
     sessionid = request.cookies.get('session')
     _log_response(usuario, sessionid, response)
     dados = response.json()
+    if isinstance(dados, dict):
+        dados.update(kwargs)
+
     if resposta_sensivel(dados):
         return jsonify(remove_info_sensiveis(dados))
 
-    return jsonify(response.json())
+    return jsonify(dados)
 
 
 def limpa_nos(nos):
@@ -222,12 +225,16 @@ def api_findNodes():
         " return n limit 100" % (label, prop, val),
         "resultDataContents": ["row", "graph"]
     }]}
+
     response = requests.post(
         _ENDERECO_NEO4J % '/db/data/transaction/commit',
         data=json.dumps(query),
         auth=_AUTH,
         headers=_HEADERS)
-    return respostajson(response)
+
+    numero_de_nos = conta_nos(label, prop, val)
+
+    return respostajson(response, numero_de_nos=numero_de_nos)
 
 
 @app.route("/api/nextNodes")

--- a/sinapse/start.py
+++ b/sinapse/start.py
@@ -82,6 +82,22 @@ def remove_info_sensiveis(resposta):
     return resp
 
 
+def conta_nos(label, prop, val):
+    query = {"statements": [{
+        "statement": "MATCH (n: %s { %s:toUpper('%s')})"
+        " return count(n)" % (label, prop, val),
+        "resultDataContents": ["row", "graph"]
+    }]}
+
+    response = requests.post(
+        _ENDERECO_NEO4J % '/db/data/transaction/commit',
+        data=json.dumps(query),
+        auth=_AUTH,
+        headers=_HEADERS)
+
+    return response.json()['results'][0]['data'][0]['row'][0]
+
+
 def resposta_sensivel(resposta):
     def parser_dicionario(dicionario, chave):
         if isinstance(dicionario, dict):

--- a/sinapse/tests/fixtures.py
+++ b/sinapse/tests/fixtures.py
@@ -890,19 +890,6 @@ casos_servicos = [
         'metodo': responses.POST
     },
     {
-        'nome': 'api_findNodes',
-        'endereco': '/db/data/transaction/commit',
-        'servico': '/api/findNodes',
-        'resposta': resposta_filterNodes_ok,
-        'requisicao': request_filterNodes_ok,
-        'query_string': {
-            'label': 'pessoa',
-            'prop': 'nome',
-            'val': 'DANIEL CARVALHO BELCHIOR'
-        },
-        'metodo': responses.POST
-    },
-    {
         'nome': 'api_nextNodes',
         'endereco': '/db/data/transaction/commit',
         'servico': '/api/nextNodes',

--- a/sinapse/tests/fixtures.py
+++ b/sinapse/tests/fixtures.py
@@ -890,17 +890,6 @@ casos_servicos = [
         'metodo': responses.POST
     },
     {
-        'nome': 'api_nextNodes',
-        'endereco': '/db/data/transaction/commit',
-        'servico': '/api/nextNodes',
-        'resposta': resposta_nextNodes_ok,
-        'requisicao': request_nextNodes_ok,
-        'query_string': {
-            "node_id": 395989945
-        },
-        'metodo': responses.POST
-    },
-    {
         'nome': 'api_nodeProperties',
         'endereco': '/db/data/cypher',
         'servico': '/api/nodeProperties',

--- a/sinapse/tests/test_sinapse.py
+++ b/sinapse/tests/test_sinapse.py
@@ -18,7 +18,8 @@ from sinapse.start import (
     limpa_linhas,
     remove_info_sensiveis,
     resposta_sensivel,
-    limpa_relacoes
+    limpa_relacoes,
+    conta_nos
 )
 
 from .fixtures import (
@@ -195,6 +196,23 @@ class MetodosConsulta(unittest.TestCase):
                 caso['metodo'],
                 _ENDERECO_NEO4J % caso['endereco']
             )
+
+    @responses.activate
+    def test_conta_numero_de_nos(self):
+        resp_esperada = {
+            'results': [
+                {'columns': ['COUNT(p)'],
+                 'data': [{'row': [3], 'meta': [None]}]}], 'errors': []
+        }
+        responses.add(
+            responses.POST,
+            _ENDERECO_NEO4J % '/db/data/transaction/commit',
+            json=resp_esperada
+        )
+
+        numero_nos = conta_nos(label='pessoa', prop='nome', val='Qualque')
+
+        self.assertEqual(numero_nos, 3)
 
 
 class LogoutUsuarioFlask(FlaskTestCase):

--- a/sinapse/tests/test_sinapse.py
+++ b/sinapse/tests/test_sinapse.py
@@ -70,7 +70,9 @@ def logresponse(funcao):
     def wrapper(*args, **kwargs):
         # remove o _log_response da lista de argumentos
         args = list(args)
-        args.pop(-1)
+        for arg in list(args):
+            if arg.__dict__.get('_mock_name', '') == '_log_response':
+                args.remove(arg)
         return funcao(*args, **kwargs)
 
     return wrapper
@@ -201,7 +203,7 @@ class MetodosConsulta(unittest.TestCase):
                 _ENDERECO_NEO4J % caso['endereco']
             )
 
-    @responses.activate
+    @logresponse
     def test_resposta_nos(self):
         responses.add(
             responses.POST,
@@ -251,7 +253,7 @@ class MetodosConsulta(unittest.TestCase):
         self.assertEqual(numero_nos, 3)
 
     @mock.patch('sinapse.start.conta_nos', return_value=101)
-    @responses.activate
+    @logresponse
     def test_conta_numero_de_nos_antes_da_busca(self, _conta_nos):
         mock_resposta = mock.MagicMock()
         responses.add(
@@ -282,7 +284,7 @@ class MetodosConsulta(unittest.TestCase):
         _conta_nos.assert_called_once_with('pessoa', 'nome', 'Qualquer')
         self.assertEqual(resposta.json['numero_de_nos'], 101)
 
-    @responses.activate
+    @logresponse
     def test_resposta_expansoes(self):
         responses.add(
             responses.POST,
@@ -336,7 +338,7 @@ class MetodosConsulta(unittest.TestCase):
                          ' count(n), count(x)"}]}')
 
     @mock.patch('sinapse.start.conta_expansoes', return_value=[1, 1, 1])
-    @responses.activate
+    @logresponse
     def test_conta_numero_de_expansoes_antes_da_busca(self, _conta_nos):
         mock_resposta = mock.MagicMock()
         responses.add(


### PR DESCRIPTION
Adiciona na resposta da API o número total de nós e expansões que a busca retornou ou retornaria se não tivesse a cláusula LIMIT

Exemplo
api/findNodes:
    response: {..., 'numero_de_nos': 10}

api/nextNodes:
    response: {.... 'numero_de_expansoes': [10, 10, 10]}